### PR TITLE
support rb generic: extract cache implementation to service

### DIFF
--- a/backend/src/services/cache.js
+++ b/backend/src/services/cache.js
@@ -1,0 +1,21 @@
+let cachedStats = null;
+let cachedMtime = 0;
+
+function getCachedStats(mtimeMs) {
+  if (cachedStats && cachedMtime === mtimeMs) {
+    return cachedStats;
+  }
+  return null;
+}
+
+function setCachedStats(mtimeMs, stats) {
+  cachedMtime = mtimeMs;
+  cachedStats = stats;
+}
+
+function resetCache() {
+  cachedStats = null;
+  cachedMtime = 0;
+}
+
+module.exports = { getCachedStats, setCachedStats, resetCache };


### PR DESCRIPTION
Removed the local cache variables and instead require the cache module
This would make the caching strategy easier to maintain, allow for features like automatic cache invalidation (or expiration), and reduce risks of accidental state carry‑over during tests or between requests.